### PR TITLE
update to 0.4 and get rid of dep warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.3
-Compat
+julia 0.4
 HTTPClient

--- a/src/loader.jl
+++ b/src/loader.jl
@@ -1,12 +1,7 @@
 # Copyright (c) 2015 Ishita Takeshi
 # License is MIT
 
-
-using Compat
-
-
 include("exception.jl")
-
 
 # replace multiple whitespaces with single whitespace
 strip_line(line) = replace(strip(line), r"\s+", " ")
@@ -14,10 +9,8 @@ strip_line(line) = replace(strip(line), r"\s+", " ")
 parsefloat(x) = parse(Float64, x)
 parseint(x) = parse(Int64, x)
 
-
-isnumeric(s::String) = ismatch(r"[0-9]", s)
+isnumeric(s::AbstractString) = ismatch(r"[0-9]", s)
 iscomment(line) = startswith(line, "#")
-
 
 """
 Extract a sparse vector of `ndim` dimensions and its label
@@ -41,11 +34,9 @@ function line_to_data(line)
         throw(InvalidFormatError(error.msg))
     end
 
-    @compat begin
     if length(splitted) < 2 || startswith(splitted[2], "#")
         # no vector per line or the case such as line = "-1 #comment"
         return (Int64[], Float64[]), label
-    end
     end
 
     indices = Int64[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 import Base.Test: @test
-using Compat
 
 using SVMLightLoader
 
@@ -17,7 +16,6 @@ println("Testing line_to_data")
 
 line_to_data = SVMLightLoader.line_to_data
 
-@compat begin
 # when the format is invalid
 try line_to_data(" #comment") catch err @test isa(err, NoDataException) end
 try line_to_data("# comment") catch err @test isa(err, NoDataException) end
@@ -25,7 +23,6 @@ try line_to_data("\n") catch err @test isa(err, NoDataException) end
 try line_to_data("-1 2:1.0 5:") catch err @test isa(err, InvalidFormatError) end
 try line_to_data("-1 :3") catch err @test isa(err, InvalidFormatError) end
 try line_to_data("A") catch err @test isa(err, InvalidFormatError) end
-end
 
 (indices, values), label = line_to_data("-1")
 @test (indices, values) == (Int64[], Float64[])


### PR DESCRIPTION
I updated the code to get rid of the warnings and the compat dependency. On the next tag you should increase the `:minor` version

As a side note: are you still interested in maintaining this package? This is a very useful package and you could consider moving it to [JuliaML](https://github.com/JuliaML). I'd be happy to take over maintenance / documentation and such.
